### PR TITLE
Feature: Find by Tag

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindByNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByNameCommand.java
@@ -1,0 +1,14 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Keyword matching is case sensitive.
+ */
+public class FindByNameCommand extends FindCommand {
+
+    public FindByNameCommand(NameContainsKeywordsPredicate predicate) {
+        super(predicate);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FindByTagsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagsCommand.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.model.person.TagsContainKeywordsPredicate;
+
+/**
+ * Finds and lists all persons in address book whose tags contains any of the argument keywords.
+ * Keyword matching is case sensitive.
+ */
+public class FindByTagsCommand extends FindCommand {
+    // Note: This regex pattern will be used by the FindCommandParser to identify if the input for a find
+    // command is a FindByTagCommand. Please make sure that this regex does not clash with regexes
+    // of any other classes that extend FindCommand.
+    private static final String KEYWORDS_GROUP_NAME = "KEYWORDS";
+    private static final String ARGS_REGEX = "^" + PREFIX_TAG + "(?<" + KEYWORDS_GROUP_NAME + ">.*)";
+
+    public FindByTagsCommand(TagsContainKeywordsPredicate predicate) {
+        super(predicate);
+    }
+
+    public static boolean matchArgs(String args) {
+        return args.matches(ARGS_REGEX);
+    }
+
+    public static String getKeywordArgs(String args) {
+        Pattern pattern = Pattern.compile(ARGS_REGEX);
+        Matcher matcher = pattern.matcher(args);
+
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String keywordArgs = matcher.group(KEYWORDS_GROUP_NAME).trim();
+        return keywordArgs;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FindByTagsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagsCommand.java
@@ -2,9 +2,6 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import seedu.address.model.person.TagsContainKeywordsPredicate;
 
 /**
@@ -12,29 +9,17 @@ import seedu.address.model.person.TagsContainKeywordsPredicate;
  * Keyword matching is case sensitive.
  */
 public class FindByTagsCommand extends FindCommand {
-    // Note: This regex pattern will be used by the FindCommandParser to identify if the input for a find
-    // command is a FindByTagCommand. Please make sure that this regex does not clash with regexes
-    // of any other classes that extend FindCommand.
-    private static final String KEYWORDS_GROUP_NAME = "KEYWORDS";
-    private static final String ARGS_REGEX = "^" + PREFIX_TAG + "(?<" + KEYWORDS_GROUP_NAME + ">.*)";
+    public static final String OPTION_PREFIX = PREFIX_TAG.toString();
 
     public FindByTagsCommand(TagsContainKeywordsPredicate predicate) {
         super(predicate);
     }
 
     public static boolean matchArgs(String args) {
-        return args.matches(ARGS_REGEX);
+        return args.indexOf(OPTION_PREFIX) == 0;
     }
 
     public static String getKeywordArgs(String args) {
-        Pattern pattern = Pattern.compile(ARGS_REGEX);
-        Matcher matcher = pattern.matcher(args);
-
-        if (!matcher.matches()) {
-            return null;
-        }
-
-        String keywordArgs = matcher.group(KEYWORDS_GROUP_NAME).trim();
-        return keywordArgs;
+        return args.substring(OPTION_PREFIX.length()).trim();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindByTagsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindByTagsCommand.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
 import seedu.address.model.person.TagsContainKeywordsPredicate;
 
 /**
@@ -9,17 +7,9 @@ import seedu.address.model.person.TagsContainKeywordsPredicate;
  * Keyword matching is case sensitive.
  */
 public class FindByTagsCommand extends FindCommand {
-    public static final String OPTION_PREFIX = PREFIX_TAG.toString();
+    public static final String COMMAND_OPTION = "tag";
 
     public FindByTagsCommand(TagsContainKeywordsPredicate predicate) {
         super(predicate);
-    }
-
-    public static boolean matchArgs(String args) {
-        return args.indexOf(OPTION_PREFIX) == 0;
-    }
-
-    public static String getKeywordArgs(String args) {
-        return args.substring(OPTION_PREFIX.length()).trim();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.ReadOnlyPerson;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -17,9 +19,9 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<ReadOnlyPerson> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<ReadOnlyPerson> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
 import java.util.function.Predicate;
 
 import seedu.address.model.person.ReadOnlyPerson;
@@ -19,9 +17,12 @@ public class FindCommand extends Command {
             + "Alias: " + COMMAND_ALIAS + "\n"
             + "Options: \n"
             + "\tdefault - Find contacts whose names contain any of the specified keywords (case-sensitive)\n"
-            + "\t" + PREFIX_TAG + " - Find contacts whose tags contain any of the specified keywords (case-sensitive)\n"
+            + "\t" + FindByTagsCommand.COMMAND_OPTION
+            + " - Find contacts whose tags contain any of the specified keywords (case-sensitive)\n"
             + "Parameters: [OPTION] KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " t/ friends colleagues";
+            + "Example: \n"
+            + COMMAND_WORD + " bob alice\n"
+            + COMMAND_WORD + " -" + FindByTagsCommand.COMMAND_OPTION + " friends colleagues";
 
     private final Predicate<ReadOnlyPerson> predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -18,8 +18,8 @@ public class FindCommand extends Command {
             + "and displays them as a list with index numbers.\n"
             + "Alias: " + COMMAND_ALIAS + "\n"
             + "Options: \n"
-            + "\tdefault - Find contacts whose names contain any of the specified keywords (case-sensitive) \n"
-            + "\t" + PREFIX_TAG + " - Find contacts whose tags contain any of the specified keywords (case-sensitive) \n"
+            + "\tdefault - Find contacts whose names contain any of the specified keywords (case-sensitive)\n"
+            + "\t" + PREFIX_TAG + " - Find contacts whose tags contain any of the specified keywords (case-sensitive)\n"
             + "Parameters: [OPTION] KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " t/ friends colleagues";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,23 +1,27 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 import java.util.function.Predicate;
 
 import seedu.address.model.person.ReadOnlyPerson;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case sensitive.
+ * Finds and lists all persons in address book who meet the specified criteria.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
     public static final String COMMAND_ALIAS = "f";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons who meet the specified criteria"
+            + "and displays them as a list with index numbers.\n"
             + "Alias: " + COMMAND_ALIAS + "\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Options: \n"
+            + "\tdefault - Find contacts whose names contain any of the specified keywords (case-sensitive) \n"
+            + "\t" + PREFIX_TAG + " - Find contacts whose tags contain any of the specified keywords (case-sensitive) \n"
+            + "Parameters: [OPTION] KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " t/ friends colleagues";
 
     private final Predicate<ReadOnlyPerson> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.Arrays;
 
+import seedu.address.logic.commands.FindByNameCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -27,7 +28,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindByNameCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -38,18 +38,18 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
+        OptionBearingArgument opArgs = new OptionBearingArgument(args);
+        String filteredArgs = opArgs.getFilteredArgs();
 
-        if (FindByTagsCommand.matchArgs(trimmedArgs)) {
-            String keywordArgs = FindByTagsCommand.getKeywordArgs(trimmedArgs);
-            checkArgsNotEmpty(keywordArgs);
+        checkArgsNotEmpty(filteredArgs);
 
-            String[] tagKeywords = parseKeywords(keywordArgs);
+        if (opArgs.getOptions().contains(FindByTagsCommand.COMMAND_OPTION)) {
+            String[] tagKeywords = parseKeywords(filteredArgs);
             TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(Arrays.asList(tagKeywords));
             return new FindByTagsCommand(predicate);
         } else {
-            checkArgsNotEmpty(trimmedArgs);
-            String[] nameKeywords = parseKeywords(trimmedArgs);
+            checkArgsNotEmpty(opArgs.getFilteredArgs());
+            String[] nameKeywords = parseKeywords(filteredArgs);
             NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
             return new FindByNameCommand(predicate);
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -5,14 +5,32 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import java.util.Arrays;
 
 import seedu.address.logic.commands.FindByNameCommand;
+import seedu.address.logic.commands.FindByTagsCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagsContainKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+
+    private String[] parseKeywords(String keywordArgs) {
+        String[] keywords = keywordArgs.split("\\s+");
+        return keywords;
+    }
+
+    /**
+     * Utility function to check that the input arguments is not empty.
+     * Throws a parse exception if it is empty.
+     */
+    private void checkArgsNotEmpty(String args) throws ParseException {
+        if (args == null || args.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+    }
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -21,14 +39,20 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        if (FindByTagsCommand.matchArgs(trimmedArgs)) {
+            String keywordArgs = FindByTagsCommand.getKeywordArgs(trimmedArgs);
+            checkArgsNotEmpty(keywordArgs);
+
+            String[] tagKeywords = parseKeywords(keywordArgs);
+            TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(Arrays.asList(tagKeywords));
+            return new FindByTagsCommand(predicate);
+        } else {
+            checkArgsNotEmpty(trimmedArgs);
+            String[] nameKeywords = parseKeywords(trimmedArgs);
+            NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+            return new FindByNameCommand(predicate);
         }
-
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindByNameCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/OptionBearingArgument.java
+++ b/src/main/java/seedu/address/logic/parser/OptionBearingArgument.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_OPTION;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The OptionBearingArgument class encapsulates an argument that contains options, and handles the parsing and filtering
+ * of these options from the argument.
+ */
+public class OptionBearingArgument {
+
+    private String rawArgs;
+    private Set<String> optionsList;
+    private String filteredArgs;
+
+    /**
+     * Constructs an OptionBearingArgument for the input argument string.
+     */
+    public OptionBearingArgument(String args) {
+        String trimmedArgs = args.trim();
+        rawArgs = trimmedArgs;
+        parse(rawArgs);
+    }
+
+    /**
+     * Parses the string to get the list of options, and a filtered argument string with the options removed.
+     */
+    private void parse(String args) {
+        String[] splitArgs = args.split("\\s+");
+        optionsList = Arrays.stream(splitArgs)
+                .filter(arg -> arg.startsWith(PREFIX_OPTION.getPrefix()))
+                .map(optionArg -> optionArg.substring(PREFIX_OPTION.getPrefix().length())) // drop the leading prefix
+                .collect(Collectors.toCollection(HashSet::new));
+
+        filteredArgs = Arrays.stream(splitArgs)
+                .filter(arg -> !arg.startsWith(PREFIX_OPTION.getPrefix()))
+                .collect(Collectors.joining(" "));
+    }
+
+    public String getRawArgs() {
+        return rawArgs;
+    }
+
+    public Set<String> getOptions() {
+        return optionsList;
+    }
+
+    public String getFilteredArgs() {
+        return filteredArgs;
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/TagsContainKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagsContainKeywordsPredicate.java
@@ -1,0 +1,38 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Tests that a {@code ReadOnlyPerson}'s {@code Name} matches any of the keywords given.
+ */
+public class TagsContainKeywordsPredicate implements Predicate<ReadOnlyPerson> {
+    private final List<String> keywords;
+
+    public TagsContainKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    private boolean personTagsMatchKeyword(ReadOnlyPerson person, String keyword) {
+        Set<Tag> tags = person.getTags();
+        return tags.stream().anyMatch(tag -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword));
+    }
+
+    @Override
+    public boolean test(ReadOnlyPerson person) {
+        return keywords.stream()
+                .anyMatch(keyword -> personTagsMatchKeyword(person, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagsContainKeywordsPredicate // instanceof handles nulls
+                && this.keywords.equals(((TagsContainKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import seedu.address.logic.commands.FindByNameCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
@@ -31,7 +32,7 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindByNameCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,8 +9,10 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import seedu.address.logic.commands.FindByNameCommand;
+import seedu.address.logic.commands.FindByTagsCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagsContainKeywordsPredicate;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -22,6 +24,22 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 public class FindCommandParserTest {
 
     private FindCommandParser parser = new FindCommandParser();
+
+    @Test
+    public void parse_emptyTagArgs_throwsParseException() {
+        assertParseFailure(parser, "t/     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validTagArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindCommand =
+                new FindByTagsCommand(new TagsContainKeywordsPredicate(Arrays.asList("colleagues", "friends")));
+        assertParseSuccess(parser, "t/ colleagues friends", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, "t/   \n colleagues \t friends \n", expectedFindCommand);
+    }
 
     @Test
     public void parse_emptyArg_throwsParseException() {

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -27,7 +27,8 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyTagArgs_throwsParseException() {
-        assertParseFailure(parser, "t/     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-tag     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -35,10 +36,10 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindByTagsCommand(new TagsContainKeywordsPredicate(Arrays.asList("colleagues", "friends")));
-        assertParseSuccess(parser, "t/ colleagues friends", expectedFindCommand);
+        assertParseSuccess(parser, "-tag colleagues friends", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "t/   \n colleagues \t friends \n", expectedFindCommand);
+        assertParseSuccess(parser, "-tag   \n colleagues \t friends \n", expectedFindCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/OptionBearingArgumentTest.java
+++ b/src/test/java/seedu/address/logic/parser/OptionBearingArgumentTest.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class OptionBearingArgumentTest {
+
+    @Test
+    public void optionBearingArgument_argsWithoutOptions_success() {
+        String args = "a/123 some building #01-01 e/hello@world.com";
+        OptionBearingArgument opArg = new OptionBearingArgument(args);
+
+        assertEquals(args, opArg.getRawArgs());
+        assertEquals(args, opArg.getFilteredArgs());
+        assertTrue(opArg.getOptions().isEmpty());
+    }
+
+    @Test
+    public void optionBearingArgument_argsWithSingleLeadingOption_success() {
+        String args = "-opt a/123 some building #01-01 e/hello@world.com";
+        OptionBearingArgument opArg = new OptionBearingArgument(args);
+
+        String expectedFilteredArgs = "a/123 some building #01-01 e/hello@world.com";
+        Set<String> expectedOptions = new HashSet<>(Arrays.asList("opt"));
+        assertEquals(args, opArg.getRawArgs());
+        assertEquals(expectedFilteredArgs, opArg.getFilteredArgs());
+        assertEquals(expectedOptions, opArg.getOptions());
+    }
+
+    @Test
+    public void optionBearingArgument_argsWithSingleEmbeddedOption_success() {
+        String args = "a/123 some building -opt #01-01 e/hello@world.com";
+        OptionBearingArgument opArg = new OptionBearingArgument(args);
+
+        String expectedFilteredArgs = "a/123 some building #01-01 e/hello@world.com";
+        Set<String> expectedOptions = new HashSet<>(Arrays.asList("opt"));
+        assertEquals(args, opArg.getRawArgs());
+        assertEquals(expectedFilteredArgs, opArg.getFilteredArgs());
+        assertEquals(expectedOptions, opArg.getOptions());
+    }
+
+    @Test
+    public void optionBearingArgument_argsWithMultipleOptions_success() {
+        String args = "-tag a/123 some building -opt #01-01 e/hello@world.com";
+        OptionBearingArgument opArg = new OptionBearingArgument(args);
+
+        String expectedFilteredArgs = "a/123 some building #01-01 e/hello@world.com";
+        Set<String> expectedOptions = new HashSet<>(Arrays.asList("opt", "tag"));
+        assertEquals(args, opArg.getRawArgs());
+        assertEquals(expectedFilteredArgs, opArg.getFilteredArgs());
+        assertEquals(expectedOptions, opArg.getOptions());
+    }
+}

--- a/src/test/java/seedu/address/model/person/TagsContainKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/TagsContainKeywordsPredicateTest.java
@@ -1,0 +1,70 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class TagsContainKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        TagsContainKeywordsPredicate firstPredicate = new TagsContainKeywordsPredicate(firstPredicateKeywordList);
+        TagsContainKeywordsPredicate secondPredicate = new TagsContainKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagsContainKeywordsPredicate firstPredicateCopy = new TagsContainKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tagsContainKeywords_returnsTrue() {
+        // One keyword
+        TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(Collections.singletonList("friend"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withTags("friend").build()));
+
+        // Multiple keywords
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("friend", "colleague"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withTags("friend", "colleague").build()));
+
+        // Only one matching keyword
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("friend", "colleague"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withTags("friend").build()));
+
+        // Mixed-case keywords
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("fRiEnD", "coLleaGue"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withTags("friend", "colleague").build()));
+    }
+
+    @Test
+    public void test_tagsDoNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
+
+        // Non-matching keyword
+        predicate = new TagsContainKeywordsPredicate(Arrays.asList("family"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withTags("friend").build()));
+    }
+}


### PR DESCRIPTION
Refactored FindCommand to abstract out finding by name functionality to a child FindByNameCommand class.

Added FindByTagCommand and TagsContainKeywordPredicate to handle filtering contacts by tags.

Updated FindCommandParser to identify if input arguments are for a find by tag command.

Possible example of how a single command can be extended to have multiple options while retaining the same keyword syntax, which should be easier for the user to remember compared to having a new keyword/command for every functionality.

Closes #73 
Closes #75 