### PR TITLE
Feature: Favorite/Unfavorite Single/Multiple Contacts (New Commands)

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,7 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_MULTI = "One or more index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_MULTI = "One or more indexes provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_MULTI = "One or more index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -8,7 +8,7 @@ package seedu.address.commons.core.index;
  * base the other component is using for its index. However, after receiving the {@code Index}, that component can
  * convert it back to an int if the index will not be passed to a different component again.
  */
-public class Index {
+public class Index implements Comparable<Index> {
     private int zeroBasedIndex;
 
     /**
@@ -43,6 +43,14 @@ public class Index {
      */
     public static Index fromOneBased(int oneBasedIndex) {
         return new Index(oneBasedIndex - 1);
+    }
+
+    /**
+     * Implement comparable for usage such as {@code Collections.max}
+     */
+    @Override
+    public int compareTo(Index idx) {
+        return Double.compare(getOneBased(), idx.getOneBased());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
@@ -19,8 +19,9 @@ public class FavoriteCommand extends UndoableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Favorites the person(s) identified by the index number used in the last person listing.\n"
-            + "Parameters: INDEX (must be a positive integer) or INDEXES\n"
-            + "Example: " + COMMAND_WORD + " 1 OR " + COMMAND_WORD + " 1 2 3";
+            + "Parameters: INDEX [ADDITIONAL INDEXES] (INDEX must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1\n"
+            + "Example: " + COMMAND_WORD + " 1 2 3";
 
     public static final String MESSAGE_FAVORITE_PERSON_SUCCESS = "Added as favorite contact(s): %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
@@ -58,10 +58,10 @@ public class FavoriteCommand extends UndoableCommand {
          */
         for (Index targetIndex : targetIndexList) {
             ReadOnlyPerson personToFavorite = lastShownList.get(targetIndex.getZeroBased());
-            names += "\n★ " + personToFavorite.getName().toString();
 
             try {
                 model.toggleFavoritePerson(personToFavorite, COMMAND_WORD);
+                names += "\n★ " + personToFavorite.getName().toString();
             } catch (DuplicatePersonException dpe) {
                 throw new CommandException(EditCommand.MESSAGE_DUPLICATE_PERSON);
             } catch (PersonNotFoundException pnfe) {

--- a/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import java.util.Collections;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+
+/**
+ * Favorites the person(s) identified using it's last displayed index from the address book.
+ */
+public class FavoriteCommand extends UndoableCommand {
+
+    public static final String COMMAND_WORD = "fav";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Favorites the person(s) identified by the index number used in the last person listing.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1 OR " + COMMAND_WORD + " 1 2 3";
+
+    public static final String MESSAGE_FAVORITE_PERSON_SUCCESS = "Added as favorite contact(s): %1$s";
+
+    private final List<Index> targetIndexList;
+
+    public FavoriteCommand(List<Index> targetIndexList) {
+        this.targetIndexList = targetIndexList;
+    }
+
+    @Override
+    public CommandResult executeUndoableCommand() throws CommandException {
+        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
+        String names = "";
+
+        /*
+         * First, efficiently check whether user input any index larger than address book size with Collections.max
+         * This is to avoid the following situation:
+         *
+         * E.g. AddressBook size is 100
+         * Execute "fav 6 7 101 8 9" ->
+         * persons at indexes 7 and 8 gets favorited but method halts due to CommandException for index 101 and
+         * person at index 9 and beyond does not get favorited
+         */
+        if (Collections.max(targetIndexList).getOneBased() > lastShownList.size()) {
+            if (targetIndexList.size() > 1) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_MULTI);
+            } else {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+        }
+
+        /*
+         * Then, as long no exception is thrown above i.e. all index are within boundaries,
+         * the following loop will run
+         */
+        for (Index targetIndex : targetIndexList) {
+            ReadOnlyPerson personToFavorite = lastShownList.get(targetIndex.getZeroBased());
+            names += "\n★ " + personToFavorite.getName().toString();
+
+            try {
+                model.toggleFavoritePerson(personToFavorite, COMMAND_WORD);
+            } catch (DuplicatePersonException dpe) {
+                throw new CommandException(EditCommand.MESSAGE_DUPLICATE_PERSON);
+            } catch (PersonNotFoundException pnfe) {
+                throw new AssertionError("The target person cannot be missing");
+            }
+        }
+
+        return new CommandResult(String.format(MESSAGE_FAVORITE_PERSON_SUCCESS, names));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.person.Favorite;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;

--- a/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
@@ -6,6 +6,7 @@ import java.util.List;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.Favorite;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
@@ -19,7 +20,7 @@ public class FavoriteCommand extends UndoableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Favorites the person(s) identified by the index number used in the last person listing.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Parameters: INDEX (must be a positive integer) or INDEXES\n"
             + "Example: " + COMMAND_WORD + " 1 OR " + COMMAND_WORD + " 1 2 3";
 
     public static final String MESSAGE_FAVORITE_PERSON_SUCCESS = "Added as favorite contact(s): %1$s";
@@ -70,5 +71,12 @@ public class FavoriteCommand extends UndoableCommand {
         }
 
         return new CommandResult(String.format(MESSAGE_FAVORITE_PERSON_SUCCESS, names));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FavoriteCommand // instanceof handles nulls
+                && this.targetIndexList.equals(((FavoriteCommand) other).targetIndexList)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UnFavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnFavoriteCommand.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import java.util.Collections;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+
+/**
+ * Unfavorites the person(s) identified using it's last displayed index from the address book.
+ */
+public class UnFavoriteCommand extends UndoableCommand {
+
+    public static final String COMMAND_WORD = "unfav";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unfavorites the person(s) identified by the index number used in the last person listing.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1 OR " + COMMAND_WORD + " 1 2 3";
+
+    public static final String MESSAGE_UNFAVORITE_PERSON_SUCCESS = "Removed from favorite contact(s): %1$s";
+
+    private final List<Index> targetIndexList;
+
+    public UnFavoriteCommand(List<Index> targetIndexList) {
+        this.targetIndexList = targetIndexList;
+    }
+
+    @Override
+    public CommandResult executeUndoableCommand() throws CommandException {
+        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
+        String names = "";
+
+        /*
+         * First, efficiently check whether user input any index larger than address book size with Collections.max
+         * This is to avoid the following situation:
+         *
+         * E.g. AddressBook size is 100
+         * Execute "fav 6 7 101 8 9" ->
+         * persons at indexes 7 and 8 gets favorited but method halts due to CommandException for index 101 and
+         * person at index 9 and beyond does not get favorited
+         */
+        if (Collections.max(targetIndexList).getOneBased() > lastShownList.size()) {
+            if (targetIndexList.size() > 1) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_MULTI);
+            } else {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+        }
+
+        /*
+         * Then, as long no exception is thrown above i.e. all index are within boundaries,
+         * the following loop will run
+         */
+        for (Index targetIndex : targetIndexList) {
+            ReadOnlyPerson personToUnFavorite = lastShownList.get(targetIndex.getZeroBased());
+            names += "\n" + personToUnFavorite.getName().toString();
+
+            try {
+                model.toggleFavoritePerson(personToUnFavorite, COMMAND_WORD);
+            } catch (DuplicatePersonException dpe) {
+                throw new CommandException(EditCommand.MESSAGE_DUPLICATE_PERSON);
+            } catch (PersonNotFoundException pnfe) {
+                throw new AssertionError("The target person cannot be missing");
+            }
+        }
+
+        return new CommandResult(String.format(MESSAGE_UNFAVORITE_PERSON_SUCCESS, names));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnFavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnFavoriteCommand.java
@@ -19,7 +19,7 @@ public class UnFavoriteCommand extends UndoableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Unfavorites the person(s) identified by the index number used in the last person listing.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Parameters: INDEX (must be a positive integer) or INDEXES\n"
             + "Example: " + COMMAND_WORD + " 1 OR " + COMMAND_WORD + " 1 2 3";
 
     public static final String MESSAGE_UNFAVORITE_PERSON_SUCCESS = "Removed from favorite contact(s): %1$s";
@@ -70,5 +70,13 @@ public class UnFavoriteCommand extends UndoableCommand {
         }
 
         return new CommandResult(String.format(MESSAGE_UNFAVORITE_PERSON_SUCCESS, names));
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UnFavoriteCommand // instanceof handles nulls
+                && this.targetIndexList.equals(((UnFavoriteCommand) other).targetIndexList)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UnFavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnFavoriteCommand.java
@@ -72,7 +72,6 @@ public class UnFavoriteCommand extends UndoableCommand {
         return new CommandResult(String.format(MESSAGE_UNFAVORITE_PERSON_SUCCESS, names));
     }
 
-
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.FavoriteCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
@@ -20,6 +21,7 @@ import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UnFavoriteCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -57,6 +59,12 @@ public class AddressBookParser {
         case EditCommand.COMMAND_WORD:
         case EditCommand.COMMAND_ALIAS:
             return new EditCommandParser().parse(arguments);
+
+        case FavoriteCommand.COMMAND_WORD:
+            return new FavoriteCommandParser().parse(arguments);
+
+        case UnFavoriteCommand.COMMAND_WORD:
+            return new UnFavoriteCommandParser().parse(arguments);
 
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/FavoriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FavoriteCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.FavoriteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new FavoriteCommand object
+ */
+public class FavoriteCommandParser implements Parser<FavoriteCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the FavoriteCommand
+     * and returns an FavoriteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FavoriteCommand parse(String args) throws ParseException {
+        try {
+            List<Index> indexList = ParserUtil.parseMultipleIndexes(args);
+            return new FavoriteCommand(indexList);
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavoriteCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -56,14 +56,11 @@ public class ParserUtil {
      * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static List<Index> parseMultipleIndexes(String args) throws IllegalValueException {
-        // Example of proper args: " 1 2 3" (has a space in front)
-        List<String> argsList = Arrays.asList(args.split(" "));
+        // Example of proper args: " 1 2 3" (has a space in front) -> Hence apply trim() first then split
+        List<String> argsList = Arrays.asList(args.trim().split("\\s+")); // split by one or more whitespaces
         List<Index> indexList = new ArrayList<>();
 
         for (String index : argsList) {
-            if (index.isEmpty()) { // An empty space stored as a result of String.split()
-                continue; // Skip all the extra empty space(s) to allow input such as: "fav 1  2   3    4"
-            }
             indexList.add(parseIndex(index)); // Add each valid index into indexList
         }
         return indexList;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,8 +2,11 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -45,6 +48,22 @@ public class ParserUtil {
             throw new IllegalValueException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses {@code args} into an {@code List<Index>} and returns it.
+     * Used for commands that need to parse multiple indexes
+     * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
+     */
+    public static List<Index> parseMultipleIndexes(String args) throws IllegalValueException {
+        List<String> argsList = Arrays.asList(args.split(" ")); // example of args: " 1 2 3" (has a space in front)
+        List<Index> indexList = new ArrayList<>();
+
+        for (String index : argsList.subList(1, argsList.size())) { // skip first item in argsList since it is a space
+            Index i = parseIndex(index);
+            indexList.add(i); // Add each valid index into indexList
+        }
+        return indexList;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -56,10 +56,11 @@ public class ParserUtil {
      * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static List<Index> parseMultipleIndexes(String args) throws IllegalValueException {
-        List<String> argsList = Arrays.asList(args.split(" ")); // example of args: " 1 2 3" (has a space in front)
+        // Example of args: " 1 2 3" (has a space in front). Hence, remove the first space -> then split
+        List<String> argsList = Arrays.asList(args.replaceFirst(" ", "").split(" "));
         List<Index> indexList = new ArrayList<>();
 
-        for (String index : argsList.subList(1, argsList.size())) { // skip first item in argsList since it is a space
+        for (String index : argsList) {
             Index i = parseIndex(index);
             indexList.add(i); // Add each valid index into indexList
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -56,13 +56,15 @@ public class ParserUtil {
      * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static List<Index> parseMultipleIndexes(String args) throws IllegalValueException {
-        // Example of args: " 1 2 3" (has a space in front). Hence, remove the first space -> then split
-        List<String> argsList = Arrays.asList(args.replaceFirst(" ", "").split(" "));
+        // Example of proper args: " 1 2 3" (has a space in front)
+        List<String> argsList = Arrays.asList(args.split(" "));
         List<Index> indexList = new ArrayList<>();
 
         for (String index : argsList) {
-            Index i = parseIndex(index);
-            indexList.add(i); // Add each valid index into indexList
+            if (index.isEmpty()) { // An empty space stored as a result of String.split()
+                continue; // Skip all the extra empty space(s) to allow input such as: "fav 1  2   3    4"
+            }
+            indexList.add(parseIndex(index)); // Add each valid index into indexList
         }
         return indexList;
     }

--- a/src/main/java/seedu/address/logic/parser/UnFavoriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnFavoriteCommandParser.java
@@ -10,12 +10,12 @@ import seedu.address.logic.commands.UnFavoriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new FavoriteCommand object
+ * Parses input arguments and creates a new UnFavoriteCommand object
  */
 public class UnFavoriteCommandParser implements Parser<UnFavoriteCommand> {
     /**
-     * Parses the given {@code String} of arguments in the context of the FavoriteCommand
-     * and returns an FavoriteCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the UnFavoriteCommand
+     * and returns an UnFavoriteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public UnFavoriteCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/UnFavoriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnFavoriteCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.UnFavoriteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new FavoriteCommand object
+ */
+public class UnFavoriteCommandParser implements Parser<UnFavoriteCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the FavoriteCommand
+     * and returns an FavoriteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnFavoriteCommand parse(String args) throws ParseException {
+        try {
+            List<Index> indexList = ParserUtil.parseMultipleIndexes(args);
+            return new UnFavoriteCommand(indexList);
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnFavoriteCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 import java.util.Set;
 
 import javafx.collections.ObservableList;
+import seedu.address.logic.commands.FavoriteCommand;
+import seedu.address.model.person.Favorite;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList;
@@ -151,6 +153,29 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean removePerson(ReadOnlyPerson key) throws PersonNotFoundException {
         if (persons.remove(key)) {
             return true;
+        } else {
+            throw new PersonNotFoundException();
+        }
+    }
+
+    /**
+     * Sets {@code personToFav} favorite field to true or false according to {@code type}.
+     * Replaces the given person {@code target} in the list with {@code personToFav}.
+     *
+     * @throws DuplicatePersonException if updating the person's details causes the person to be equivalent to
+     *      another existing person in the list.
+     * @throws PersonNotFoundException if {@code target} could not be found in the list.
+     */
+    public void toggleFavoritePerson(ReadOnlyPerson target, String type)
+            throws DuplicatePersonException, PersonNotFoundException {
+        if (persons.contains(target)) {
+            Person personToFav = new Person(target);
+            if (type.equals(FavoriteCommand.COMMAND_WORD)) {
+                personToFav.setFavorite(new Favorite(true));  // Favorite
+            } else {
+                personToFav.setFavorite(new Favorite(false)); // UnFavorite
+            }
+            persons.setPerson(target, personToFav);
         } else {
             throw new PersonNotFoundException();
         }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -31,6 +31,10 @@ public interface Model {
     /** Adds all persons in the given collection */
     void addPersons(Collection<ReadOnlyPerson> persons);
 
+    /** Favorites or unfavorites the given person */
+    void toggleFavoritePerson(ReadOnlyPerson target, String type)
+            throws DuplicatePersonException, PersonNotFoundException;
+
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      *

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -111,6 +111,14 @@ public class ModelManager extends ComponentManager implements Model {
         indicateAddressBookChanged();
     }
 
+    @Override
+    public void toggleFavoritePerson(ReadOnlyPerson target, String type)
+            throws DuplicatePersonException, PersonNotFoundException {
+        requireAllNonNull(target, type);
+        addressBook.toggleFavoritePerson(target, type);
+        indicateAddressBookChanged();
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FavoriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavoriteCommandTest.java
@@ -54,6 +54,8 @@ public class FavoriteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() throws Exception {
+        showFirstPersonOnly(model);
+
         ReadOnlyPerson personToFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         FavoriteCommand favoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
 
@@ -62,6 +64,7 @@ public class FavoriteCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.toggleFavoritePerson(personToFavorite, FavoriteCommand.COMMAND_WORD);
+        model.updateFilteredPersonList(p -> true);
 
         assertCommandSuccess(favoriteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/FavoriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavoriteCommandTest.java
@@ -35,7 +35,8 @@ public class FavoriteCommandTest {
         ReadOnlyPerson personToFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         FavoriteCommand favoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
 
-        String expectedMessage = String.format(FavoriteCommand.MESSAGE_FAVORITE_PERSON_SUCCESS, personToFavorite);
+        String expectedMessage = String.format(
+                FavoriteCommand.MESSAGE_FAVORITE_PERSON_SUCCESS, "\n★ " + personToFavorite.getName().toString());
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.toggleFavoritePerson(personToFavorite, FavoriteCommand.COMMAND_WORD);
@@ -53,16 +54,14 @@ public class FavoriteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() throws Exception {
-        showFirstPersonOnly(model);
-
         ReadOnlyPerson personToFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         FavoriteCommand favoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
 
-        String expectedMessage = String.format(FavoriteCommand.MESSAGE_FAVORITE_PERSON_SUCCESS, personToFavorite);
+        String expectedMessage = String.format(
+                FavoriteCommand.MESSAGE_FAVORITE_PERSON_SUCCESS, "\n★ " + personToFavorite.getName().toString());
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.toggleFavoritePerson(personToFavorite, FavoriteCommand.COMMAND_WORD);
-        showNoPerson(expectedModel);
 
         assertCommandSuccess(favoriteCommand, model, expectedMessage, expectedModel);
     }
@@ -109,14 +108,5 @@ public class FavoriteCommandTest {
         FavoriteCommand favoriteCommand = new FavoriteCommand(indexList);
         favoriteCommand.setData(model, getNullStorage(), new CommandHistory(), new UndoRedoStack());
         return favoriteCommand;
-    }
-
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoPerson(Model model) {
-        model.updateFilteredPersonList(p -> false);
-
-        assert model.getFilteredPersonList().isEmpty();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FavoriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FavoriteCommandTest.java
@@ -1,0 +1,122 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showFirstPersonOnly;
+import static seedu.address.testutil.StorageUtil.getNullStorage;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ReadOnlyPerson;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code FavoriteCommand}.
+ */
+public class FavoriteCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() throws Exception {
+        ReadOnlyPerson personToFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        FavoriteCommand favoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
+
+        String expectedMessage = String.format(FavoriteCommand.MESSAGE_FAVORITE_PERSON_SUCCESS, personToFavorite);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.toggleFavoritePerson(personToFavorite, FavoriteCommand.COMMAND_WORD);
+
+        assertCommandSuccess(favoriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() throws Exception {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        FavoriteCommand favoriteCommand = prepareCommand(Arrays.asList(outOfBoundIndex));
+
+        assertCommandFailure(favoriteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() throws Exception {
+        showFirstPersonOnly(model);
+
+        ReadOnlyPerson personToFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        FavoriteCommand favoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
+
+        String expectedMessage = String.format(FavoriteCommand.MESSAGE_FAVORITE_PERSON_SUCCESS, personToFavorite);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.toggleFavoritePerson(personToFavorite, FavoriteCommand.COMMAND_WORD);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(favoriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showFirstPersonOnly(model);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        FavoriteCommand favoriteCommand = prepareCommand(Arrays.asList(outOfBoundIndex));
+
+        assertCommandFailure(favoriteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        FavoriteCommand favoriteFirstCommand = new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON));
+        FavoriteCommand favoriteSecondCommand = new FavoriteCommand(Arrays.asList(INDEX_SECOND_PERSON));
+
+        // same object -> returns true
+        assertTrue(favoriteFirstCommand.equals(favoriteFirstCommand));
+
+        // same values -> returns true
+        FavoriteCommand favoriteFirstCommandCopy = new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON));
+        assertTrue(favoriteFirstCommand.equals(favoriteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(favoriteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(favoriteFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(favoriteFirstCommand.equals(favoriteSecondCommand));
+    }
+
+    /**
+     * Returns a {@code FavoriteCommand} with the parameter {@code index}.
+     */
+    private FavoriteCommand prepareCommand(List<Index> indexList) {
+        FavoriteCommand favoriteCommand = new FavoriteCommand(indexList);
+        favoriteCommand.setData(model, getNullStorage(), new CommandHistory(), new UndoRedoStack());
+        return favoriteCommand;
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredPersonList(p -> false);
+
+        assert model.getFilteredPersonList().isEmpty();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UnFavoriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnFavoriteCommandTest.java
@@ -1,0 +1,122 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showFirstPersonOnly;
+import static seedu.address.testutil.StorageUtil.getNullStorage;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ReadOnlyPerson;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code UnFavoriteCommand}.
+ */
+public class UnFavoriteCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() throws Exception {
+        ReadOnlyPerson personToUnFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
+
+        String expectedMessage = String.format(UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS, personToUnFavorite);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.toggleFavoritePerson(personToUnFavorite, UnFavoriteCommand.COMMAND_WORD);
+
+        assertCommandSuccess(unFavoriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() throws Exception {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(outOfBoundIndex));
+
+        assertCommandFailure(unFavoriteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() throws Exception {
+        showFirstPersonOnly(model);
+
+        ReadOnlyPerson personToUnFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
+
+        String expectedMessage = String.format(UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS, personToUnFavorite);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.toggleFavoritePerson(personToUnFavorite, UnFavoriteCommand.COMMAND_WORD);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(unFavoriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showFirstPersonOnly(model);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(outOfBoundIndex));
+
+        assertCommandFailure(unFavoriteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        UnFavoriteCommand unFavoriteFirstCommand = new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON));
+        UnFavoriteCommand favoriteSecondCommand = new UnFavoriteCommand(Arrays.asList(INDEX_SECOND_PERSON));
+
+        // same object -> returns true
+        assertTrue(unFavoriteFirstCommand.equals(unFavoriteFirstCommand));
+
+        // same values -> returns true
+        UnFavoriteCommand unFavoriteFirstCommandCopy = new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON));
+        assertTrue(unFavoriteFirstCommand.equals(unFavoriteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unFavoriteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unFavoriteFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(unFavoriteFirstCommand.equals(favoriteSecondCommand));
+    }
+
+    /**
+     * Returns a {@code UnFavoriteCommand} with the parameter {@code index}.
+     */
+    private UnFavoriteCommand prepareCommand(List<Index> indexList) {
+        UnFavoriteCommand unFavoriteCommand = new UnFavoriteCommand(indexList);
+        unFavoriteCommand.setData(model, getNullStorage(), new CommandHistory(), new UndoRedoStack());
+        return unFavoriteCommand;
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredPersonList(p -> false);
+
+        assert model.getFilteredPersonList().isEmpty();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UnFavoriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnFavoriteCommandTest.java
@@ -35,7 +35,8 @@ public class UnFavoriteCommandTest {
         ReadOnlyPerson personToUnFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
 
-        String expectedMessage = String.format(UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS, personToUnFavorite);
+        String expectedMessage = String.format(
+                UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS, "\n" + personToUnFavorite.getName().toString());
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.toggleFavoritePerson(personToUnFavorite, UnFavoriteCommand.COMMAND_WORD);
@@ -53,16 +54,14 @@ public class UnFavoriteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() throws Exception {
-        showFirstPersonOnly(model);
-
         ReadOnlyPerson personToUnFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
 
-        String expectedMessage = String.format(UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS, personToUnFavorite);
+        String expectedMessage = String.format(
+                UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS, "\n" + personToUnFavorite.getName().toString());
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.toggleFavoritePerson(personToUnFavorite, UnFavoriteCommand.COMMAND_WORD);
-        showNoPerson(expectedModel);
 
         assertCommandSuccess(unFavoriteCommand, model, expectedMessage, expectedModel);
     }
@@ -109,14 +108,5 @@ public class UnFavoriteCommandTest {
         UnFavoriteCommand unFavoriteCommand = new UnFavoriteCommand(indexList);
         unFavoriteCommand.setData(model, getNullStorage(), new CommandHistory(), new UndoRedoStack());
         return unFavoriteCommand;
-    }
-
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
-    private void showNoPerson(Model model) {
-        model.updateFilteredPersonList(p -> false);
-
-        assert model.getFilteredPersonList().isEmpty();
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -125,7 +125,7 @@ public class AddressBookParserTest {
     public void parseCommand_favorite_multi() throws Exception {
         FavoriteCommand command = (FavoriteCommand) parser.parseCommand(
                 FavoriteCommand.COMMAND_WORD + " "
-                        + INDEX_FIRST_PERSON.getOneBased()
+                        + INDEX_FIRST_PERSON.getOneBased() + " "
                         + INDEX_SECOND_PERSON.getOneBased());
         assertEquals(new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON)), command);
     }
@@ -232,7 +232,7 @@ public class AddressBookParserTest {
     public void parseCommand_unFavorite_multi() throws Exception {
         UnFavoriteCommand command = (UnFavoriteCommand) parser.parseCommand(
                 UnFavoriteCommand.COMMAND_WORD + " "
-                        + INDEX_FIRST_PERSON.getOneBased()
+                        + INDEX_FIRST_PERSON.getOneBased() + " "
                         + INDEX_SECOND_PERSON.getOneBased());
         assertEquals(new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON)), command);
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,12 +22,14 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FavoriteCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UnFavoriteCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -109,6 +112,22 @@ public class AddressBookParserTest {
     public void parseCommand_exitAlias() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_ALIAS) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_ALIAS + " 3") instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_favorite() throws Exception {
+        FavoriteCommand command = (FavoriteCommand) parser.parseCommand(
+                FavoriteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)), command);
+    }
+
+    @Test
+    public void parseCommand_favorite_multi() throws Exception {
+        FavoriteCommand command = (FavoriteCommand) parser.parseCommand(
+                FavoriteCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST_PERSON.getOneBased()
+                        + INDEX_SECOND_PERSON.getOneBased());
+        assertEquals(new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON)), command);
     }
 
     @Test
@@ -200,6 +219,22 @@ public class AddressBookParserTest {
     public void parseCommand_undoCommandAlias_returnsUndoCommand() throws Exception {
         assertTrue(parser.parseCommand(UndoCommand.COMMAND_ALIAS) instanceof UndoCommand);
         assertTrue(parser.parseCommand("u 3") instanceof UndoCommand);
+    }
+
+    @Test
+    public void parseCommand_unFavorite() throws Exception {
+        UnFavoriteCommand command = (UnFavoriteCommand) parser.parseCommand(
+                UnFavoriteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)), command);
+    }
+
+    @Test
+    public void parseCommand_unFavorite_multi() throws Exception {
+        UnFavoriteCommand command = (UnFavoriteCommand) parser.parseCommand(
+                UnFavoriteCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST_PERSON.getOneBased()
+                        + INDEX_SECOND_PERSON.getOneBased());
+        assertEquals(new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FavoriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FavoriteCommandParserTest.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.FavoriteCommand;
+
+public class FavoriteCommandParserTest {
+
+    private FavoriteCommandParser parser = new FavoriteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsFavoriteCommand() {
+        assertParseSuccess(parser, "1", new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavoriteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FavoriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FavoriteCommandParserTest.java
@@ -17,12 +17,12 @@ public class FavoriteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFavoriteCommand() {
-        assertParseSuccess(parser, " 1", new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
+        assertParseSuccess(parser, "1", new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, " a",
+        assertParseFailure(parser, "a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavoriteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FavoriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FavoriteCommandParserTest.java
@@ -17,12 +17,12 @@ public class FavoriteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFavoriteCommand() {
-        assertParseSuccess(parser, "1", new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
+        assertParseSuccess(parser, " 1", new FavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a",
+        assertParseFailure(parser, " a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavoriteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -11,6 +11,13 @@ import org.junit.Test;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the FavoriteCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the FavoriteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
 public class FindCommandParserTest {
 
     private FindCommandParser parser = new FindCommandParser();

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -55,6 +55,12 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseMultiIndex_invalidInput_throwsIllegalValueException() throws Exception {
+        thrown.expect(IllegalValueException.class);
+        ParserUtil.parseMultipleIndexes("  1 2 3"); // Two trailing spaces in front
+    }
+
+    @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -6,10 +6,13 @@ import static org.junit.Assert.assertTrue;
 
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -17,6 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -57,7 +61,7 @@ public class ParserUtilTest {
     @Test
     public void parseMultiIndex_invalidInput_throwsIllegalValueException() throws Exception {
         thrown.expect(IllegalValueException.class);
-        ParserUtil.parseMultipleIndexes("  1 2 3"); // Two trailing spaces in front
+        ParserUtil.parseMultipleIndexes("1 2 3 a"); // Two trailing spaces in front
     }
 
     @Test
@@ -67,6 +71,17 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+    }
+
+    @Test
+    public void parseMultiIndex_validInput_success() throws Exception {
+        List<Index> expectedIndexList = Arrays.asList(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, INDEX_THIRD_PERSON);
+
+        // No whitespaces
+        assertEquals(expectedIndexList, ParserUtil.parseMultipleIndexes("1 2 3"));
+
+        // Leading and trailing whitespaces
+        assertEquals(expectedIndexList, ParserUtil.parseMultipleIndexes(" 1  2   3    "));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UnFavoriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnFavoriteCommandParserTest.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.UnFavoriteCommand;
+
+public class UnFavoriteCommandParserTest {
+
+    private UnFavoriteCommandParser parser = new UnFavoriteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsUnFavoriteCommand() {
+        assertParseSuccess(parser, "1", new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnFavoriteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UnFavoriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnFavoriteCommandParserTest.java
@@ -11,18 +11,25 @@ import org.junit.Test;
 
 import seedu.address.logic.commands.UnFavoriteCommand;
 
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the UnFavoriteCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the UnFavoriteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
 public class UnFavoriteCommandParserTest {
 
     private UnFavoriteCommandParser parser = new UnFavoriteCommandParser();
 
     @Test
     public void parse_validArgs_returnsUnFavoriteCommand() {
-        assertParseSuccess(parser, " 1", new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
+        assertParseSuccess(parser, "1", new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, " a",
+        assertParseFailure(parser, "a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnFavoriteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UnFavoriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnFavoriteCommandParserTest.java
@@ -17,12 +17,12 @@ public class UnFavoriteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsUnFavoriteCommand() {
-        assertParseSuccess(parser, "1", new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
+        assertParseSuccess(parser, " 1", new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a",
+        assertParseFailure(parser, " a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnFavoriteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/testutil/modelstubs/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/modelstubs/ModelStub.java
@@ -50,6 +50,12 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void toggleFavoritePerson(ReadOnlyPerson target, String type)
+            throws DuplicatePersonException, PersonNotFoundException {
+        fail("This method should not be called.");
+    }
+
+    @Override
     public ObservableList<ReadOnlyPerson> getFilteredPersonList() {
         fail("This method should not be called.");
         return null;


### PR DESCRIPTION
## Summary of this PR
- Add new `FavoriteCommand` and `UnFavoriteCommand` that is capable of batch operation i.e. favoriting and unfavoriting multiple contacts

- Implement `Comparable` in Index.java to use `Collections.max`

- Add new `parseMultipleIndexes` method in ParserUtil.java for convenience of parsing multiple indexes

- Add new test cases and update various existing tests wherever the new commands impacts

Closes #49 

## Usage

Ways to add person(s) as favorite contact:
- `add f/`
- `edit 1 f/`
- `fav 1`
- `fav 1 2 3`

Ways to remove person(s) from favorite contact:
- `edit 1 uf/`
- `unfav 1`
- `unfav 1 2 3`

## Milestones
1.1: New "Favorite" Field + Add/Edit Favorite Contacts + UI Display of Favorite Contacts
**1.2: New FavoriteCommand and UnFavoriteCommand to do batch favoriting and unfavoriting + (Upcoming) List Favorite Contacts Seperately**