### PR TITLE
Feature: Delete by Tags

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteByIndexCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteByIndexCommand.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.commands;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.ReadOnlyPerson;
+
+/**
+ * Deletes persons from the list identified by their indexes in the last displayed list in the address book.
+ */
+public class DeleteByIndexCommand extends DeleteCommand {
+    private Collection<Index> targetIndexes;
+
+    public DeleteByIndexCommand(Collection<Index> indexes) {
+        targetIndexes = indexes;
+    }
+
+    /**
+     * Returns the list of persons in the last shown list referenced by the collection of indexes provided.
+     */
+    private Collection<ReadOnlyPerson> mapPersonsToIndexes(Collection<Index> indexes) throws CommandException {
+        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
+        HashSet<ReadOnlyPerson> personSet = new HashSet<>();
+        for (Index index : indexes) {
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+            ReadOnlyPerson person = lastShownList.get(index.getZeroBased());
+            personSet.add(person);
+        }
+
+        return personSet;
+    }
+
+    @Override
+    public Collection<ReadOnlyPerson> getPersonsToDelete() throws CommandException {
+        return mapPersonsToIndexes(targetIndexes);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteByIndexCommand // instanceof handles nulls
+                && this.targetIndexes.equals(((DeleteByIndexCommand) other).targetIndexes)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteByTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteByTagCommand.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.commands;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.TagsContainKeywordsPredicate;
+
+/**
+ * Deletes persons from the list identified by their indexes in the last displayed list in the address book.
+ */
+public class DeleteByTagCommand extends DeleteCommand {
+    public static final String COMMAND_OPTION = "tag";
+
+    private Collection<String> targetTags;
+
+    public DeleteByTagCommand(Collection<String> tags) {
+        targetTags = tags;
+    }
+
+    /**
+     * Returns the list of persons in the last shown list referenced by the collection of tags provided.
+     */
+    private Collection<ReadOnlyPerson> mapPersonsToTags(Collection<String> tags) {
+        TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(tags);
+        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
+        List<ReadOnlyPerson> persons = lastShownList.stream().filter(predicate).collect(Collectors.toList());
+
+        return persons;
+    }
+
+    @Override
+    public Collection<ReadOnlyPerson> getPersonsToDelete() {
+        return mapPersonsToTags(targetTags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteByTagCommand // instanceof handles nulls
+                && this.targetTags.equals(((DeleteByTagCommand) other).targetTags)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,61 +1,63 @@
 package seedu.address.logic.commands;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
- * Deletes a person identified using it's last displayed index from the address book.
+ * Represents a command that deletes persons from the addressbook identified by some input parameter
  */
-public class DeleteCommand extends UndoableCommand {
+public abstract class DeleteCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "delete";
     public static final String COMMAND_ALIAS = "d";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the last person listing.\n"
+            + ": Deletes the specified persons from the address book\n"
             + "Alias: " + COMMAND_ALIAS + "\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Options: \n"
+            + "\tdefault - Deletes the persons identified by the index numbers "
+            + "(must be positive integers) used in the last person listing.\n"
+            + "\t" + DeleteByTagCommand.COMMAND_OPTION
+            + " - Deletes the perons in the last person listing with the specified tags.\n"
+            + "Parameters: [OPTION] IDENTIFIER [MORE_IDENTIFIERS]...\n"
+            + "Example:\n"
+            + COMMAND_WORD + " 1 2\n"
+            + COMMAND_WORD + " -" + DeleteByTagCommand.COMMAND_OPTION + " friends colleagues";
 
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person(s): %1$s";
 
     private List<Index> targetIndexList = new ArrayList<>();
 
-    public DeleteCommand(List<Index> targetIndexList) {
-        this.targetIndexList = targetIndexList;
-    }
-
     @Override
     public CommandResult executeUndoableCommand() throws CommandException {
+        Collection<ReadOnlyPerson> personsToDelete = getPersonsToDelete();
+        StringBuilder deletedPersons = new StringBuilder();
 
-        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
-        StringBuilder people = new StringBuilder();
-
-        for (Index i : this.targetIndexList) {
-            if (i.getZeroBased() >= lastShownList.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-            }
-
-            ReadOnlyPerson personToDelete = lastShownList.get(i.getZeroBased());
-
+        for (ReadOnlyPerson personToDelete : personsToDelete) {
             try {
                 model.deletePerson(personToDelete);
             } catch (PersonNotFoundException pnfe) {
                 assert false : "The target person cannot be missing";
             }
 
-            people.append("\n");
-            people.append(personToDelete);
+            deletedPersons.append("\n");
+            deletedPersons.append(personToDelete);
         }
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, people));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, deletedPersons));
     }
+
+    /**
+     * Returns the collection of persons to be deleted.
+     * To be implemented by the classes inheriting this class.
+     */
+    public abstract Collection<ReadOnlyPerson> getPersonsToDelete() throws CommandException;
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,12 +1,14 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.ParserUtil.parseWhitespaceSeparatedStrings;
 
-import java.util.Collections;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.DeleteByIndexCommand;
+import seedu.address.logic.commands.DeleteByTagCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -14,22 +16,40 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new DeleteCommand object
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
-
+    /**
+     * Utility function to check that the input arguments is not empty.
+     * Throws a parse exception if it is empty.
+     */
+    private void checkArgsNotEmpty(String args) throws ParseException {
+        if (args == null || args.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+    }
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns an DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        try {
-            List<Index> indexList = ParserUtil.parseMultipleIndexes(args);
-            // Sorts and reverses list to allow input indexes to be in any order
-            Collections.sort(indexList, Collections.reverseOrder());
-            return new DeleteCommand(indexList);
-        } catch (IllegalValueException ive) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        // check that the raw args are not empty before processing
+        checkArgsNotEmpty(args);
+        OptionBearingArgument opArgs = new OptionBearingArgument(args);
+        String filteredArgs = opArgs.getFilteredArgs();
+        // check that the filtered args are not empty
+        checkArgsNotEmpty(filteredArgs);
+
+        if (opArgs.getOptions().contains(DeleteByTagCommand.COMMAND_OPTION)) {
+            List<String> tags = parseWhitespaceSeparatedStrings(filteredArgs);
+            return new DeleteByTagCommand(tags);
+        } else {
+            try {
+                List<Index> indexes = ParserUtil.parseMultipleIndexes(filteredArgs);
+                return new DeleteByIndexCommand(indexes);
+            } catch (IllegalValueException ive) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
         }
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,8 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.ParserUtil.parseWhitespaceSeparatedStrings;
 
-import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.logic.commands.FindByNameCommand;
 import seedu.address.logic.commands.FindByTagsCommand;
@@ -15,12 +16,6 @@ import seedu.address.model.person.TagsContainKeywordsPredicate;
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
-
-    private String[] parseKeywords(String keywordArgs) {
-        String[] keywords = keywordArgs.split("\\s+");
-        return keywords;
-    }
-
     /**
      * Utility function to check that the input arguments is not empty.
      * Throws a parse exception if it is empty.
@@ -38,19 +33,21 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        // check that the raw args are not empty before processing
+        checkArgsNotEmpty(args);
         OptionBearingArgument opArgs = new OptionBearingArgument(args);
         String filteredArgs = opArgs.getFilteredArgs();
-
+        // check that the filtered args are not empty
         checkArgsNotEmpty(filteredArgs);
 
         if (opArgs.getOptions().contains(FindByTagsCommand.COMMAND_OPTION)) {
-            String[] tagKeywords = parseKeywords(filteredArgs);
-            TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(Arrays.asList(tagKeywords));
+            List<String> tagKeywords = parseWhitespaceSeparatedStrings(filteredArgs);
+            TagsContainKeywordsPredicate predicate = new TagsContainKeywordsPredicate(tagKeywords);
             return new FindByTagsCommand(predicate);
         } else {
             checkArgsNotEmpty(opArgs.getFilteredArgs());
-            String[] nameKeywords = parseKeywords(filteredArgs);
-            NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+            List<String> nameKeywords = parseWhitespaceSeparatedStrings(filteredArgs);
+            NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(nameKeywords);
             return new FindByNameCommand(predicate);
         }
     }

--- a/src/main/java/seedu/address/logic/parser/OptionBearingArgument.java
+++ b/src/main/java/seedu/address/logic/parser/OptionBearingArgument.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OPTION;
 
 import java.util.Arrays;
@@ -21,6 +22,7 @@ public class OptionBearingArgument {
      * Constructs an OptionBearingArgument for the input argument string.
      */
     public OptionBearingArgument(String args) {
+        requireNonNull(args);
         String trimmedArgs = args.trim();
         rawArgs = trimmedArgs;
         parse(rawArgs);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -40,6 +40,15 @@ public class ParserUtil {
     public static final String MESSAGE_INSUFFICIENT_PARTS = "Number of parts must be more than 1.";
 
     /**
+     * Splits {@code args} by whitespace and returns it
+     */
+    public static List<String> parseWhitespaceSeparatedStrings(String args) {
+        requireNonNull(args);
+        String[] splitArgs = args.split("\\s+");
+        return Arrays.asList(splitArgs);
+    }
+
+    /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
      * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).

--- a/src/main/java/seedu/address/model/person/TagsContainKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagsContainKeywordsPredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -11,9 +12,9 @@ import seedu.address.model.tag.Tag;
  * Tests that a {@code ReadOnlyPerson}'s {@code Name} matches any of the keywords given.
  */
 public class TagsContainKeywordsPredicate implements Predicate<ReadOnlyPerson> {
-    private final List<String> keywords;
+    private final Collection<String> keywords;
 
-    public TagsContainKeywordsPredicate(List<String> keywords) {
+    public TagsContainKeywordsPredicate(Collection<String> keywords) {
         this.keywords = keywords;
     }
 


### PR DESCRIPTION
Allows users to delete contacts by tags by passing the `-tag` option to the delete command.

e.g. `d -tag friends` will delete all users in the *current* user listing with the `friends` tag

Closes #83 