### PR TITLE
Fix: UI Window size and resizing issues

### DIFF
--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -10,8 +10,8 @@ import java.util.Objects;
 public class GuiSettings implements Serializable {
 
     //@@author keithsoc
-    private static final double DEFAULT_HEIGHT = 900;
-    private static final double DEFAULT_WIDTH = 1600;
+    private static final double DEFAULT_HEIGHT = 835;
+    private static final double DEFAULT_WIDTH = 1100;
     //@@author
 
     private Double windowWidth;

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -21,7 +21,7 @@ public class UserPrefs {
 
     //@@author keithsoc
     public UserPrefs() {
-        this.setGuiSettings(1600, 900, 0, 0);
+        this.setGuiSettings(1100, 835, 0, 0);
         this.setThemeSettings("view/ThemeDay.css", "view/ThemeDayExtensions.css");
     }
     //@@author

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -36,8 +36,8 @@ public class MainWindow extends UiPart<Region> {
     private static final String ICON = "/images/kaypoh_icon_32.png";
     private static final String FXML = "MainWindow.fxml";
     //@@author keithsoc
-    private static final int MIN_HEIGHT = 900;
-    private static final int MIN_WIDTH = 1600;
+    private static final int MIN_HEIGHT = 700;
+    private static final int MIN_WIDTH = 600;
     //@@author
     private double xOffset = 0;
     private double yOffset = 0;
@@ -106,7 +106,7 @@ public class MainWindow extends UiPart<Region> {
         enableMovableWindow();
         enableMinimiseWindow();
         enableMaximiseWindow();
-        UiResize.enableResizableWindow(primaryStage);
+        UiResize.enableResizableWindow(primaryStage, MIN_WIDTH, MIN_HEIGHT, Double.MAX_VALUE, Double.MAX_VALUE);
         //@@author
 
         setAccelerators();
@@ -277,6 +277,7 @@ public class MainWindow extends UiPart<Region> {
             xOffset = event.getSceneX();
             yOffset = event.getSceneY();
         });
+
         menuBar.setOnMouseDragged((event) -> {
             primaryStage.setX(event.getScreenX() - xOffset);
             primaryStage.setY(event.getScreenY() - yOffset);

--- a/src/main/java/seedu/address/ui/UiResize.java
+++ b/src/main/java/seedu/address/ui/UiResize.java
@@ -13,6 +13,10 @@ import javafx.stage.Stage;
 //@@author keithsoc-reused
 /**
  * Manages resizing of UI Window by adding mouse event listeners to each UI component.
+ * To be used when JavaFX StageStyle is set to TRANSPARENT or UNDECORATED.
+ *
+ * By: Evgenii Kanivets and Alexander.Berg
+ * Adapted From: https://stackoverflow.com/questions/19455059/allow-user-to-resize-an-undecorated-stage
  */
 public class UiResize {
 
@@ -20,13 +24,23 @@ public class UiResize {
      * Registers an event handler for the Scene in the specified Stage (top-level UI container)
      * @param stage
      */
-    public static void enableResizableWindow(Stage stage) {
+    public static void enableResizableWindow(Stage stage,
+                                             double minWidth,
+                                             double minHeight,
+                                             double maxWidth,
+                                             double maxHeight) {
         ResizeHandler resizeHandler = new ResizeHandler(stage);
         stage.getScene().addEventHandler(MouseEvent.MOUSE_MOVED, resizeHandler);
         stage.getScene().addEventHandler(MouseEvent.MOUSE_PRESSED, resizeHandler);
         stage.getScene().addEventHandler(MouseEvent.MOUSE_DRAGGED, resizeHandler);
         stage.getScene().addEventHandler(MouseEvent.MOUSE_EXITED, resizeHandler);
         stage.getScene().addEventHandler(MouseEvent.MOUSE_EXITED_TARGET, resizeHandler);
+
+        resizeHandler.setMinWidth(minWidth);
+        resizeHandler.setMinHeight(minHeight);
+        resizeHandler.setMaxWidth(maxWidth);
+        resizeHandler.setMaxHeight(maxHeight);
+
         ObservableList<Node> children = stage.getScene().getRoot().getChildrenUnmodifiable();
         for (Node child : children) {
             addHandlerToNodes(child, resizeHandler);
@@ -38,7 +52,7 @@ public class UiResize {
      * @param node
      * @param handler
      */
-    public static void addHandlerToNodes(Node node, EventHandler<MouseEvent> handler) {
+    private static void addHandlerToNodes(Node node, EventHandler<MouseEvent> handler) {
         node.addEventHandler(MouseEvent.MOUSE_MOVED, handler);
         node.addEventHandler(MouseEvent.MOUSE_PRESSED, handler);
         node.addEventHandler(MouseEvent.MOUSE_DRAGGED, handler);
@@ -63,8 +77,42 @@ public class UiResize {
         private double startX = 0;
         private double startY = 0;
 
+        // Max and min sizes for controlled stage
+        private double minWidth;
+        private double maxWidth;
+        private double minHeight;
+        private double maxHeight;
+
         public ResizeHandler(Stage stage) {
             this.stage = stage;
+        }
+
+        public void setMinWidth(double minWidth) {
+            this.minWidth = minWidth;
+        }
+
+        public void setMinHeight(double minHeight) {
+            this.minHeight = minHeight;
+        }
+
+        public void setMaxWidth(double maxWidth) {
+            this.maxWidth = maxWidth;
+        }
+
+        public void setMaxHeight(double maxHeight) {
+            this.maxHeight = maxHeight;
+        }
+
+        private void setStageWidth(double width) {
+            width = Math.min(width, maxWidth);
+            width = Math.max(width, minWidth);
+            stage.setWidth(width);
+        }
+
+        private void setStageHeight(double height) {
+            height = Math.min(height, maxHeight);
+            height = Math.max(height, minHeight);
+            stage.setHeight(height);
         }
 
         @Override
@@ -77,7 +125,7 @@ public class UiResize {
             double sceneWidth = scene.getWidth();
             double sceneHeight = scene.getHeight();
 
-            if (MouseEvent.MOUSE_MOVED.equals(mouseEventType) == true) {
+            if (MouseEvent.MOUSE_MOVED.equals(mouseEventType)) {
                 if (mouseEventX < border && mouseEventY < border) {
                     cursorEvent = Cursor.NW_RESIZE;
                 } else if (mouseEventX < border && mouseEventY > sceneHeight - border) {
@@ -101,40 +149,38 @@ public class UiResize {
             } else if (MouseEvent.MOUSE_EXITED.equals(mouseEventType)
                     || MouseEvent.MOUSE_EXITED_TARGET.equals(mouseEventType)) {
                 scene.setCursor(Cursor.DEFAULT);
-            } else if (MouseEvent.MOUSE_PRESSED.equals(mouseEventType) == true) {
+            } else if (MouseEvent.MOUSE_PRESSED.equals(mouseEventType)) {
                 startX = stage.getWidth() - mouseEventX;
                 startY = stage.getHeight() - mouseEventY;
-            } else if (MouseEvent.MOUSE_DRAGGED.equals(mouseEventType) == true) {
+            } else if (MouseEvent.MOUSE_DRAGGED.equals(mouseEventType)) {
 
-                if (Cursor.DEFAULT.equals(cursorEvent) == false) {
-                    if (Cursor.W_RESIZE.equals(cursorEvent) == false && Cursor.E_RESIZE.equals(cursorEvent) == false) {
+                if (!Cursor.DEFAULT.equals(cursorEvent)) {
+                    if (!Cursor.W_RESIZE.equals(cursorEvent) && !Cursor.E_RESIZE.equals(cursorEvent)) {
                         double minHeight = stage.getMinHeight() > (border * 2) ? stage.getMinHeight() : (border * 2);
-                        if (Cursor.NW_RESIZE.equals(cursorEvent) == true
-                                || Cursor.N_RESIZE.equals(cursorEvent) == true
-                                || Cursor.NE_RESIZE.equals(cursorEvent) == true) {
+                        if (Cursor.NW_RESIZE.equals(cursorEvent) || Cursor.N_RESIZE.equals(cursorEvent)
+                                || Cursor.NE_RESIZE.equals(cursorEvent)) {
                             if (stage.getHeight() > minHeight || mouseEventY < 0) {
-                                stage.setHeight(stage.getY() - mouseEvent.getScreenY() + stage.getHeight());
+                                setStageHeight(stage.getY() - mouseEvent.getScreenY() + stage.getHeight());
                                 stage.setY(mouseEvent.getScreenY());
                             }
                         } else {
                             if (stage.getHeight() > minHeight || mouseEventY + startY - stage.getHeight() > 0) {
-                                stage.setHeight(mouseEventY + startY);
+                                setStageHeight(mouseEventY + startY);
                             }
                         }
                     }
 
-                    if (Cursor.N_RESIZE.equals(cursorEvent) == false && Cursor.S_RESIZE.equals(cursorEvent) == false) {
+                    if (!Cursor.N_RESIZE.equals(cursorEvent) && !Cursor.S_RESIZE.equals(cursorEvent)) {
                         double minWidth = stage.getMinWidth() > (border * 2) ? stage.getMinWidth() : (border * 2);
-                        if (Cursor.NW_RESIZE.equals(cursorEvent) == true
-                                || Cursor.W_RESIZE.equals(cursorEvent) == true
-                                || Cursor.SW_RESIZE.equals(cursorEvent) == true) {
+                        if (Cursor.NW_RESIZE.equals(cursorEvent) || Cursor.W_RESIZE.equals(cursorEvent)
+                                || Cursor.SW_RESIZE.equals(cursorEvent)) {
                             if (stage.getWidth() > minWidth || mouseEventX < 0) {
-                                stage.setWidth(stage.getX() - mouseEvent.getScreenX() + stage.getWidth());
+                                setStageWidth(stage.getX() - mouseEvent.getScreenX() + stage.getWidth());
                                 stage.setX(mouseEvent.getScreenX());
                             }
                         } else {
                             if (stage.getWidth() > minWidth || mouseEventX + startX - stage.getWidth() > 0) {
-                                stage.setWidth(mouseEventX + startX);
+                                setStageWidth(mouseEventX + startX);
                             }
                         }
                     }

--- a/src/main/java/seedu/address/ui/UiTheme.java
+++ b/src/main/java/seedu/address/ui/UiTheme.java
@@ -15,7 +15,7 @@ public class UiTheme {
     public static final String THEME_DAY_EXTENSIONS = "view/ThemeDayExtensions.css";
     public static final String THEME_NIGHT_EXTENSIONS = "view/ThemeNightExtensions.css";
 
-    private static UiTheme uiTheme = new UiTheme();
+    private static UiTheme instance;
     private Scene scene;
     private BrowserPanel browserPanel;
 
@@ -27,7 +27,10 @@ public class UiTheme {
      * @return instance of UiTheme
      */
     public static UiTheme getInstance() {
-        return uiTheme;
+        if (instance == null) {
+            instance = new UiTheme();
+        }
+        return instance;
     }
 
     /**

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
     </StackPane>
 
     <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
-        <VBox fx:id="personList" minWidth="535" prefWidth="535" SplitPane.resizableWithParent="false">
+        <VBox fx:id="personList" minWidth="530" prefWidth="530" SplitPane.resizableWithParent="false">
             <padding>
                 <Insets bottom="0" left="20" right="10" top="5" />
             </padding>


### PR DESCRIPTION
## Summary of this PR

- Fixed minimum allowable window width and height (for resizing)
- Fixed default starting window width and height (a height just enough to view first 4 contacts and a width that provides a reasonable fit for the whole application)
- Fixed resizing of window going beyond allowable minimum width and height
- Decreased person card list width by 5 pixels
- Update UiTheme Singleton getInstance() method to be similar to EventCenter's method for consistency

This fixes #112 and fixes #113.