### PR TITLE
Fix/Update: Favorite & Unfavorite Feature + Profile Photo Coloring

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavoriteCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -24,28 +26,34 @@ public class FavoriteCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " 1\n"
             + "Example: " + COMMAND_WORD + " 1 2 3";
 
-    public static final String MESSAGE_FAVORITE_PERSON_SUCCESS = "Added as favorite contact(s): %1$s";
+    public static final String MESSAGE_FAVORITE_PERSON_SUCCESS = "Added as favorite contact(s): ";
+    public static final String MESSAGE_FAVORITE_PERSON_FAILURE = "These contact(s) has already been "
+            + "added as favorites: ";
 
     private final List<Index> targetIndexList;
+    private final Set<ReadOnlyPerson> targetPersonList;
+    private final StringBuilder allNameList;
+    private final StringBuilder successNameList;
+    private final StringBuilder failureNameList;
 
     public FavoriteCommand(List<Index> targetIndexList) {
         this.targetIndexList = targetIndexList;
+        this.targetPersonList = new LinkedHashSet<>();
+        this.allNameList = new StringBuilder();
+        this.successNameList = new StringBuilder();
+        this.failureNameList = new StringBuilder();
     }
 
-    @Override
-    public CommandResult executeUndoableCommand() throws CommandException {
-        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
-        StringBuilder names = new StringBuilder();
-
-        /*
-         * First, efficiently check whether user input any index larger than address book size with Collections.max
-         * This is to avoid the following situation:
-         *
-         * E.g. AddressBook size is 100
-         * Execute "fav 6 7 101 8 9" ->
-         * persons at indexes 7 and 8 gets favorited but method halts due to CommandException for index 101 and
-         * person at index 9 and beyond does not get favorited
-         */
+    /**
+     * Efficiently check whether user input any index larger than address book size with Collections.max
+     * This is to avoid the following situation:
+     *
+     * E.g. AddressBook size is 100
+     * Execute "fav 6 7 101 8 9" ->
+     * persons at indexes 7 and 8 gets favorited but method halts due to CommandException for index 101 and
+     * person at index 9 and beyond does not get favorited.
+     */
+    private void checkIndexBoundaries(List<ReadOnlyPerson> lastShownList) throws CommandException {
         if (Collections.max(targetIndexList).getOneBased() > lastShownList.size()) {
             if (targetIndexList.size() > 1) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_MULTI);
@@ -53,18 +61,69 @@ public class FavoriteCommand extends UndoableCommand {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
+    }
 
-        /*
-         * Then, as long no exception is thrown above i.e. all index are within boundaries,
-         * the following loop will run
-         */
+    /**
+     * Stores all persons to favorite into {@code targetPersonList} found from the index(es) used in last shown list.
+     * {@code targetPersonList} uses a LinkedHashSet implementation for the following purposes:
+     * 1. Prevent duplicates (of persons) resulting from such an input: fav 1 1 1
+     * 2. Preserve insertion order (since {@code targetIndexList} is sorted)
+     */
+    private void getPersonsToFavorite(List<ReadOnlyPerson> lastShownList) {
         for (Index targetIndex : targetIndexList) {
             ReadOnlyPerson personToFavorite = lastShownList.get(targetIndex.getZeroBased());
+            if (!isAlreadyFavorite(personToFavorite)) { // Add person into set
+                targetPersonList.add(personToFavorite);
+            } else { // Do not add person into set, append into failure name list instead
+                failureNameList.append("\n\t- ");
+                failureNameList.append(personToFavorite.getName().toString());
+            }
+        }
+    }
 
+    /**
+     * Checks if {@code person} is already a favorite contact.
+     */
+    private boolean isAlreadyFavorite(ReadOnlyPerson person) {
+        return person.getFavorite().isFavorite();
+    }
+
+    /**
+     * Adds all appropriate String messages into {@code allNameList}.
+     */
+    private String compileAllNames() {
+        if (successNameList.length() != 0 && failureNameList.length() != 0) {
+            allNameList.append(MESSAGE_FAVORITE_PERSON_SUCCESS);
+            allNameList.append(successNameList);
+            allNameList.append("\n");
+            allNameList.append(MESSAGE_FAVORITE_PERSON_FAILURE);
+            allNameList.append(failureNameList);
+        } else if (successNameList.length() != 0 && failureNameList.length() == 0) {
+            allNameList.append(MESSAGE_FAVORITE_PERSON_SUCCESS);
+            allNameList.append(successNameList);
+        } else {
+            allNameList.append(MESSAGE_FAVORITE_PERSON_FAILURE);
+            allNameList.append(failureNameList);
+        }
+        return allNameList.toString();
+    }
+
+    @Override
+    public CommandResult executeUndoableCommand() throws CommandException {
+        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
+
+        checkIndexBoundaries(lastShownList);
+        /*
+         * As long no exception is thrown above i.e. all index are within boundaries,
+         * the following codes will run
+         */
+        getPersonsToFavorite(lastShownList);
+
+        for (ReadOnlyPerson personToFavorite : targetPersonList) {
             try {
                 model.toggleFavoritePerson(personToFavorite, COMMAND_WORD);
-                names.append("\n★ ");
-                names.append(personToFavorite.getName().toString());
+                successNameList.append("\n\t★ ");
+                successNameList.append(personToFavorite.getName().toString());
             } catch (DuplicatePersonException dpe) {
                 throw new CommandException(EditCommand.MESSAGE_DUPLICATE_PERSON);
             } catch (PersonNotFoundException pnfe) {
@@ -72,7 +131,7 @@ public class FavoriteCommand extends UndoableCommand {
             }
         }
 
-        return new CommandResult(String.format(MESSAGE_FAVORITE_PERSON_SUCCESS, names));
+        return new CommandResult(compileAllNames());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnFavoriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnFavoriteCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -20,31 +22,38 @@ public class UnFavoriteCommand extends UndoableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Unfavorites the person(s) identified by the index number used in the last person listing.\n"
-            + "Parameters: INDEX (must be a positive integer) or INDEXES\n"
-            + "Example: " + COMMAND_WORD + " 1 OR " + COMMAND_WORD + " 1 2 3";
+            + "Parameters: INDEX [ADDITIONAL INDEXES] (INDEX must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1\n"
+            + "Example: " + COMMAND_WORD + " 1 2 3";
 
-    public static final String MESSAGE_UNFAVORITE_PERSON_SUCCESS = "Removed from favorite contact(s): %1$s";
+    public static final String MESSAGE_UNFAVORITE_PERSON_SUCCESS = "Removed from favorite contact(s): ";
+    public static final String MESSAGE_UNFAVORITE_PERSON_FAILURE = "These contact(s) has not been "
+            + "added as favorites for this operation: ";
 
     private final List<Index> targetIndexList;
+    private final Set<ReadOnlyPerson> targetPersonList;
+    private final StringBuilder allNameList;
+    private final StringBuilder successNameList;
+    private final StringBuilder failureNameList;
 
     public UnFavoriteCommand(List<Index> targetIndexList) {
         this.targetIndexList = targetIndexList;
+        this.targetPersonList = new LinkedHashSet<>();
+        this.allNameList = new StringBuilder();
+        this.successNameList = new StringBuilder();
+        this.failureNameList = new StringBuilder();
     }
 
-    @Override
-    public CommandResult executeUndoableCommand() throws CommandException {
-        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
-        StringBuilder names = new StringBuilder();
-
-        /*
-         * First, efficiently check whether user input any index larger than address book size with Collections.max
-         * This is to avoid the following situation:
-         *
-         * E.g. AddressBook size is 100
-         * Execute "fav 6 7 101 8 9" ->
-         * persons at indexes 7 and 8 gets favorited but method halts due to CommandException for index 101 and
-         * person at index 9 and beyond does not get favorited
-         */
+    /**
+     * Efficiently check whether user input any index larger than address book size with Collections.max.
+     * This is to avoid the following situation:
+     *
+     * E.g. AddressBook size is 100
+     * Execute "unfav 6 7 101 8 9" ->
+     * persons at indexes 7 and 8 gets unfavorited but method halts due to CommandException for index 101 and
+     * person at index 9 and beyond does not get unfavorited.
+     */
+    private void checkIndexBoundaries(List<ReadOnlyPerson> lastShownList) throws CommandException {
         if (Collections.max(targetIndexList).getOneBased() > lastShownList.size()) {
             if (targetIndexList.size() > 1) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX_MULTI);
@@ -52,18 +61,69 @@ public class UnFavoriteCommand extends UndoableCommand {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
+    }
 
-        /*
-         * Then, as long no exception is thrown above i.e. all index are within boundaries,
-         * the following loop will run
-         */
+    /**
+     * Stores all persons to unfavorite into {@code targetPersonList} found from the index(es) used in last shown list.
+     * {@code targetPersonList} uses a LinkedHashSet implementation for the following purposes:
+     * 1. Prevent duplicates (of persons) resulting from such an input: unfav 1 1 1
+     * 2. Preserve insertion order (since {@code targetIndexList} is sorted)
+     */
+    private void getPersonsToUnFavorite(List<ReadOnlyPerson> lastShownList) {
         for (Index targetIndex : targetIndexList) {
             ReadOnlyPerson personToUnFavorite = lastShownList.get(targetIndex.getZeroBased());
+            if (isAlreadyFavorite(personToUnFavorite)) { // Add person into set
+                targetPersonList.add(personToUnFavorite);
+            } else { // Do not add person into set, append into failure name list instead
+                failureNameList.append("\n\t- ");
+                failureNameList.append(personToUnFavorite.getName().toString());
+            }
+        }
+    }
 
+    /**
+     * Checks if {@code person} is already a favorite contact.
+     */
+    private boolean isAlreadyFavorite(ReadOnlyPerson person) {
+        return person.getFavorite().isFavorite();
+    }
+
+    /**
+     * Adds all appropriate String messages into {@code allNameList}.
+     */
+    private String compileAllNames() {
+        if (successNameList.length() != 0 && failureNameList.length() != 0) {
+            allNameList.append(MESSAGE_UNFAVORITE_PERSON_SUCCESS);
+            allNameList.append(successNameList);
+            allNameList.append("\n");
+            allNameList.append(MESSAGE_UNFAVORITE_PERSON_FAILURE);
+            allNameList.append(failureNameList);
+        } else if (successNameList.length() != 0 && failureNameList.length() == 0) {
+            allNameList.append(MESSAGE_UNFAVORITE_PERSON_SUCCESS);
+            allNameList.append(successNameList);
+        } else {
+            allNameList.append(MESSAGE_UNFAVORITE_PERSON_FAILURE);
+            allNameList.append(failureNameList);
+        }
+        return allNameList.toString();
+    }
+
+    @Override
+    public CommandResult executeUndoableCommand() throws CommandException {
+        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
+
+        checkIndexBoundaries(lastShownList);
+        /*
+         * As long no exception is thrown above i.e. all index are within boundaries,
+         * the following codes will run
+         */
+        getPersonsToUnFavorite(lastShownList);
+
+        for (ReadOnlyPerson personToUnFavorite : targetPersonList) {
             try {
                 model.toggleFavoritePerson(personToUnFavorite, COMMAND_WORD);
-                names.append("\n");
-                names.append(personToUnFavorite.getName().toString());
+                successNameList.append("\n\t- ");
+                successNameList.append(personToUnFavorite.getName().toString());
             } catch (DuplicatePersonException dpe) {
                 throw new CommandException(EditCommand.MESSAGE_DUPLICATE_PERSON);
             } catch (PersonNotFoundException pnfe) {
@@ -71,7 +131,7 @@ public class UnFavoriteCommand extends UndoableCommand {
             }
         }
 
-        return new CommandResult(String.format(MESSAGE_UNFAVORITE_PERSON_SUCCESS, names));
+        return new CommandResult(compileAllNames());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/FavoriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FavoriteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Collections;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -22,6 +23,8 @@ public class FavoriteCommandParser implements Parser<FavoriteCommand> {
     public FavoriteCommand parse(String args) throws ParseException {
         try {
             List<Index> indexList = ParserUtil.parseMultipleIndexes(args);
+            // Sorts indexes in ascending order
+            Collections.sort(indexList);
             return new FavoriteCommand(indexList);
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavoriteCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/UnFavoriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnFavoriteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Collections;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -22,6 +23,8 @@ public class UnFavoriteCommandParser implements Parser<UnFavoriteCommand> {
     public UnFavoriteCommand parse(String args) throws ParseException {
         try {
             List<Index> indexList = ParserUtil.parseMultipleIndexes(args);
+            // Sorts indexes in descending order
+            Collections.sort(indexList, Collections.reverseOrder());
             return new UnFavoriteCommand(indexList);
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnFavoriteCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -41,6 +41,7 @@ public interface Model {
     //@@author marvinchin
     /** Sorts the persons in the address book based on the input {@code comparator} */
     void sortPersons(Comparator<ReadOnlyPerson> comparator);
+    //@@author
 
     //@@author keithsoc
     /** Favorites or unfavorites the given person */

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -25,7 +25,7 @@ public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
     //@@author keithsoc
-    private static HashMap<ReadOnlyPerson, String> personColors = new HashMap<>();
+    private static HashMap<String, String> personColors = new HashMap<>();
     private static HashMap<String, String> tagColors = new HashMap<>();
     private static Random random = new Random();
     private static final String defaultThemeTagColor = "#fc4465";
@@ -71,6 +71,8 @@ public class PersonCard extends UiPart<Region> {
         super(FXML);
         this.person = person;
         id.setText(displayedIndex + ". ");
+        initProfilePhoto(person);
+        initFavorite(person);
         initTags(person);
         initSocialInfos(person);
         bindListeners(person);
@@ -111,11 +113,11 @@ public class PersonCard extends UiPart<Region> {
     /**
      * Binds a profile photo background with a random pastel color and store it into personColors HashMap.
      */
-    private String getColorForPerson(ReadOnlyPerson person) {
-        if (!personColors.containsKey(person)) {
-            personColors.put(person, generateRandomPastelColor());
+    private String getColorForPerson(String name) {
+        if (!personColors.containsKey(name)) {
+            personColors.put(name, generateRandomPastelColor());
         }
-        return personColors.get(person);
+        return personColors.get(name);
     }
 
 
@@ -139,12 +141,14 @@ public class PersonCard extends UiPart<Region> {
      * so that they will be notified of any changes.
      */
     private void bindListeners(ReadOnlyPerson person) {
-        initProfilePhoto(person);
         name.textProperty().bind(Bindings.convert(person.nameProperty()));
         phone.textProperty().bind(Bindings.convert(person.phoneProperty()));
         address.textProperty().bind(Bindings.convert(person.addressProperty()));
         email.textProperty().bind(Bindings.convert(person.emailProperty()));
-        initFavorite(person);
+        person.favoriteProperty().addListener((observable, oldValue, newValue) -> {
+            favoriteImageView.setId("favoriteImageView");
+            initFavorite(person);
+        });
         person.tagProperty().addListener((observable, oldValue, newValue) -> {
             tags.getChildren().clear();
             initTags(person);
@@ -167,22 +171,22 @@ public class PersonCard extends UiPart<Region> {
         profilePhotoImageView.setClip(clip);
 
         // Add background circle with a random pastel color
+        String nameOfPerson = person.getName().toString().trim();
         Circle backgroundCircle = new Circle(value);
-        backgroundCircle.setFill(Paint.valueOf(getColorForPerson(person)));
+        backgroundCircle.setFill(Paint.valueOf(getColorForPerson(nameOfPerson)));
 
         // Add text
-        Text personInitialsText = new Text(extractInitials(person));
+        Text personInitialsText = new Text(extractInitials(nameOfPerson));
         personInitialsText.setFill(Paint.valueOf("white"));
         profilePhotoStackPane.getChildren().addAll(backgroundCircle, personInitialsText);
     }
 
     /**
-     * Extracts the initials from the name of the given {@code person}.
+     * Extracts the initials from the name of the given {@code name}.
      * Extract only one initial if the name contains a single word;
      * Extract two initials if the name contains more than one word.
      */
-    private String extractInitials (ReadOnlyPerson person) {
-        String name = person.getName().toString().trim();
+    private String extractInitials (String name) {
         int noOfInitials = 1;
         if (name.split("\\s+").length > 1) {
             noOfInitials = 2;

--- a/src/test/java/seedu/address/logic/commands/UnFavoriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnFavoriteCommandTest.java
@@ -7,11 +7,14 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showFirstPersonOnly;
 import static seedu.address.testutil.StorageUtil.getNullStorage;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -19,6 +22,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.UndoRedoStack;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -36,11 +40,37 @@ public class UnFavoriteCommandTest {
         ReadOnlyPerson personToUnFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
 
-        String expectedMessage = String.format(
-                UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS, "\n" + personToUnFavorite.getName().toString());
+        String expectedMessage = UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS
+                + "\n\t- " + personToUnFavorite.getName().toString();
 
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.toggleFavoritePerson(personToUnFavorite, UnFavoriteCommand.COMMAND_WORD);
+
+        assertCommandSuccess(unFavoriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validMultiIndexesUnfilteredList_success() throws Exception {
+        ReadOnlyPerson personAlice = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        ReadOnlyPerson personDaniel = model.getFilteredPersonList().get(INDEX_FOURTH_PERSON.getZeroBased());
+
+        Set<ReadOnlyPerson> targetPersonList = new LinkedHashSet<>();
+        targetPersonList.add(personAlice);
+        targetPersonList.add(personDaniel);
+
+        UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON, INDEX_FOURTH_PERSON));
+
+        // In TypicalPersons, Alice is already a favorite contact while Daniel is not
+        String expectedMessage = UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS
+                + "\n\t- " + personAlice.getName().toString()
+                + "\n" + UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_FAILURE
+                + "\n\t- " + personDaniel.getName().toString();
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        for (ReadOnlyPerson personToUnFavorite : targetPersonList) {
+            expectedModel.toggleFavoritePerson(personToUnFavorite, UnFavoriteCommand.COMMAND_WORD);
+        }
 
         assertCommandSuccess(unFavoriteCommand, model, expectedMessage, expectedModel);
     }
@@ -58,10 +88,10 @@ public class UnFavoriteCommandTest {
         ReadOnlyPerson personToUnFavorite = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         UnFavoriteCommand unFavoriteCommand = prepareCommand(Arrays.asList(INDEX_FIRST_PERSON));
 
-        String expectedMessage = String.format(
-                UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS, "\n" + personToUnFavorite.getName().toString());
+        String expectedMessage = UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS
+                + "\n\t- " + personToUnFavorite.getName().toString();
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.toggleFavoritePerson(personToUnFavorite, UnFavoriteCommand.COMMAND_WORD);
 
         assertCommandSuccess(unFavoriteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -248,7 +248,7 @@ public class AddressBookParserTest {
                 UnFavoriteCommand.COMMAND_WORD + " "
                         + INDEX_FIRST_PERSON.getOneBased() + " "
                         + INDEX_SECOND_PERSON.getOneBased());
-        assertEquals(new UnFavoriteCommand(Arrays.asList(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON)), command);
+        assertEquals(new UnFavoriteCommand(Arrays.asList(INDEX_SECOND_PERSON, INDEX_FIRST_PERSON)), command);
     }
     //@@author
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -117,6 +117,7 @@ public class TypicalPersons {
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
+    public static final String KEYWORD_MATCHING_KUNZ = "Kunz"; // A keyword that matches KUNZ
 
     private TypicalPersons() {} // prevents instantiation
 

--- a/src/test/java/systemtests/UnFavoriteCommandSystemTest.java
+++ b/src/test/java/systemtests/UnFavoriteCommandSystemTest.java
@@ -164,7 +164,7 @@ public class UnFavoriteCommandSystemTest extends AddressBookSystemTest {
      * Performs the same verification as {@code assertCommandSuccess(String, Model, String)} except that the
      * browser url and selected card are expected to update accordingly depending on the card
      * at {@code expectedSelectedCardIndex}.
-     * @see FavoriteCommandSystemTest#assertCommandSuccess(String, Model, String)
+     * @see UnFavoriteCommandSystemTest#assertCommandSuccess(String, Model, String)
      * @see AddressBookSystemTest#assertSelectedCardChanged(Index)
      */
     private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage,

--- a/src/test/java/systemtests/UnFavoriteCommandSystemTest.java
+++ b/src/test/java/systemtests/UnFavoriteCommandSystemTest.java
@@ -3,13 +3,10 @@ package systemtests;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.FavoriteCommand.MESSAGE_FAVORITE_PERSON_SUCCESS;
-import static seedu.address.testutil.TestUtil.getLastIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_PERSON;
+import static seedu.address.logic.commands.UnFavoriteCommand.MESSAGE_UNFAVORITE_PERSON_SUCCESS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
-import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_KUNZ;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
 
 import java.util.Arrays;
 import java.util.List;
@@ -19,8 +16,8 @@ import org.junit.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.FavoriteCommand;
 import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.UnFavoriteCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.Model;
 import seedu.address.model.person.ReadOnlyPerson;
@@ -28,110 +25,117 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 //@@author keithsoc
-public class FavoriteCommandSystemTest extends AddressBookSystemTest {
+public class UnFavoriteCommandSystemTest extends AddressBookSystemTest {
 
-    private static final String MESSAGE_INVALID_FAVORITE_COMMAND_FORMAT =
-            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FavoriteCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_UNFAVORITE_COMMAND_FORMAT =
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, UnFavoriteCommand.MESSAGE_USAGE);
 
     @Test
-    public void favorite() {
-        /* -------------- Performing favorite operation while an unfiltered list is being shown ----------------- */
+    public void unFavorite() {
+        /* ------------- Performing unfavorite operation while an unfiltered list is being shown ---------------- */
 
         /*
-         * Case: favorites the 3rd, 4th & 5th person in the list,
-         * command with leading spaces and trailing spaces -> favorited
+         * Case: unfavorites the 1st & 2nd person in the list,
+         * command with leading spaces and trailing spaces -> unfavorited
          */
         Model expectedModel = getModel();
-        String command = "     " + FavoriteCommand.COMMAND_WORD + "      " + INDEX_THIRD_PERSON.getOneBased()
-                + "       " + INDEX_FOURTH_PERSON.getOneBased() + "        " + INDEX_FIFTH_PERSON.getOneBased();
+        String command = "     " + UnFavoriteCommand.COMMAND_WORD + "      " + INDEX_FIRST_PERSON.getOneBased()
+                + "       " + INDEX_SECOND_PERSON.getOneBased();
 
-        List<Index> indexList = Arrays.asList(INDEX_THIRD_PERSON, INDEX_FOURTH_PERSON, INDEX_FIFTH_PERSON);
+        // Store in reverse just like how it would be sorted in the UnFavoriteCommandParser
+        List<Index> indexList = Arrays.asList(INDEX_SECOND_PERSON, INDEX_FIRST_PERSON);
         StringBuilder names = new StringBuilder();
         for (Index index : indexList) {
-            ReadOnlyPerson favoritedPerson = favoritePerson(expectedModel, index);
-            names.append("\n\t★ ").append(favoritedPerson.getName().toString());
+            ReadOnlyPerson unFavoritedPerson = unFavoritePerson(expectedModel, index);
+            names.append("\n\t- ").append(unFavoritedPerson.getName().toString());
         }
-        String expectedResultMessage = MESSAGE_FAVORITE_PERSON_SUCCESS + names;
+        String expectedResultMessage = MESSAGE_UNFAVORITE_PERSON_SUCCESS + names;
         assertCommandSuccess(command, expectedModel, expectedResultMessage);
 
-        /* Case: undo favoriting the 3rd, 4th & 5th person in the list -> 3rd, 4th & 5th person unfavorited */
+        /* Case: undo unfavoriting the 1st & 2nd person in the list -> 1st & 2nd person unfavorited */
         command = UndoCommand.COMMAND_WORD;
         expectedResultMessage = UndoCommand.MESSAGE_SUCCESS;
         assertCommandSuccess(command, expectedModel, expectedResultMessage);
 
-        /* Case: redo favoriting the 3rd, 4th & 5th person in the list -> 3rd, 4th & 5th person favorited again */
+        /* Case: redo unfavoriting the 1st & 2nd person in the list -> 1st & 2nd person unfavorited again */
         command = RedoCommand.COMMAND_WORD;
         for (Index index : indexList) {
-            favoritePerson(expectedModel, index);
+            unFavoritePerson(expectedModel, index);
         }
         expectedResultMessage = RedoCommand.MESSAGE_SUCCESS;
         assertCommandSuccess(command, expectedModel, expectedResultMessage);
 
-        /* ---------------- Performing favorite operation while a filtered list is being shown ------------------- */
+        /* Case: we're undoing again so that we can perform unfavorite operations (with success message) below */
+        command = UndoCommand.COMMAND_WORD;
+        expectedResultMessage = UndoCommand.MESSAGE_SUCCESS;
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
 
-        /* Case: filtered person list, favorite index within bounds of address book and person list -> favorited */
-        showPersonsWithName(KEYWORD_MATCHING_KUNZ);
+        /* ---------------- Performing unfavorite operation while a filtered list is being shown ------------------- */
+
+        /* Case: filtered person list, unfavorite index within bounds of address book and person list -> unfavorited */
+        showPersonsWithName(KEYWORD_MATCHING_MEIER);
         expectedModel = getModel();
         Index index = INDEX_FIRST_PERSON;
         assertTrue(index.getZeroBased() < getModel().getFilteredPersonList().size());
-        command = FavoriteCommand.COMMAND_WORD + " " + index.getOneBased();
-        ReadOnlyPerson favoritedPerson = favoritePerson(expectedModel, index);
-        expectedResultMessage = MESSAGE_FAVORITE_PERSON_SUCCESS + "\n\t★ " + favoritedPerson.getName().toString();
+        command = UnFavoriteCommand.COMMAND_WORD + " " + index.getOneBased();
+        ReadOnlyPerson unFavoritedPerson = unFavoritePerson(expectedModel, index);
+        expectedResultMessage = MESSAGE_UNFAVORITE_PERSON_SUCCESS + "\n\t- " + unFavoritedPerson.getName().toString();
         assertCommandSuccess(command, expectedModel, expectedResultMessage);
 
         /*
-         * Case: filtered person list, favorite index within bounds of address book but out of bounds of person list
+         * Case: filtered person list, unfavorite index within bounds of address book but out of bounds of person list
          * -> rejected
          */
-        showPersonsWithName(KEYWORD_MATCHING_KUNZ);
+        showPersonsWithName(KEYWORD_MATCHING_MEIER);
         int invalidIndex = getModel().getAddressBook().getPersonList().size();
-        command = FavoriteCommand.COMMAND_WORD + " " + invalidIndex;
+        command = UnFavoriteCommand.COMMAND_WORD + " " + invalidIndex;
         assertCommandFailure(command, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
-        /* ------------------- Performing favorite operation while a person card is selected ---------------------- */
+        /* ------------------ Performing unfavorite operation while a person card is selected --------------------- */
 
-        /* Case: favorite the selected person -> person list panel selects the person before the favoriting */
+        /* Case: unfavorite the selected person -> person list panel selects the person before the unfavoriting */
         showAllPersons();
         expectedModel = getModel();
-        Index selectedIndex = getLastIndex(expectedModel);
+        Index selectedIndex = INDEX_FIRST_PERSON;
         Index expectedIndex = Index.fromZeroBased(selectedIndex.getZeroBased());
         selectPerson(selectedIndex);
-        command = FavoriteCommand.COMMAND_WORD + " " + selectedIndex.getOneBased();
-        favoritedPerson = favoritePerson(expectedModel, selectedIndex);
-        expectedResultMessage = MESSAGE_FAVORITE_PERSON_SUCCESS + "\n\t★ " + favoritedPerson.getName().toString();
+        command = UnFavoriteCommand.COMMAND_WORD + " " + selectedIndex.getOneBased();
+        unFavoritedPerson = unFavoritePerson(expectedModel, selectedIndex);
+        expectedResultMessage = MESSAGE_UNFAVORITE_PERSON_SUCCESS + "\n\t- " + unFavoritedPerson.getName().toString();
         assertCommandSuccess(command, expectedModel, expectedResultMessage, expectedIndex);
 
-        /* ------------------------------- Performing invalid favorite operation ---------------------------------- */
+        /* ------------------------------ Performing invalid unfavorite operation --------------------------------- */
 
         /* Case: multiple invalid indexes (0 0 0) -> rejected */
-        command = FavoriteCommand.COMMAND_WORD + " 0 0 0";
-        assertCommandFailure(command, MESSAGE_INVALID_FAVORITE_COMMAND_FORMAT);
+        command = UnFavoriteCommand.COMMAND_WORD + " 0 0 0";
+        assertCommandFailure(command, MESSAGE_INVALID_UNFAVORITE_COMMAND_FORMAT);
 
         /* Case: multiple indexes with only one valid (1 0 -1 -2 -3) -> rejected */
-        command = FavoriteCommand.COMMAND_WORD + " 1 0 -1 -2 -3";
-        assertCommandFailure(command, MESSAGE_INVALID_FAVORITE_COMMAND_FORMAT);
+        command = UnFavoriteCommand.COMMAND_WORD + " 1 0 -1 -2 -3";
+        assertCommandFailure(command, MESSAGE_INVALID_UNFAVORITE_COMMAND_FORMAT);
 
         /* Case: invalid index (size + 1) -> rejected */
         Index outOfBoundsIndex = Index.fromOneBased(
                 getModel().getAddressBook().getPersonList().size() + 1);
-        command = FavoriteCommand.COMMAND_WORD + " " + outOfBoundsIndex.getOneBased();
+        command = UnFavoriteCommand.COMMAND_WORD + " " + outOfBoundsIndex.getOneBased();
         assertCommandFailure(command, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         /* Case: invalid arguments (alphabets) -> rejected */
-        assertCommandFailure(FavoriteCommand.COMMAND_WORD + " 1 2 a", MESSAGE_INVALID_FAVORITE_COMMAND_FORMAT);
+        assertCommandFailure(UnFavoriteCommand.COMMAND_WORD + " 1 2 a",
+                MESSAGE_INVALID_UNFAVORITE_COMMAND_FORMAT);
 
         /* Case: mixed case command word -> rejected */
-        assertCommandFailure("FaV 1", MESSAGE_UNKNOWN_COMMAND);
+        assertCommandFailure("UnFaV 1", MESSAGE_UNKNOWN_COMMAND);
     }
 
     /**
-     * Favorites the {@code ReadOnlyPerson} at the specified {@code index} in {@code model}'s address book.
-     * @return the favorited person
+     * Unfavorites the {@code ReadOnlyPerson} at the specified {@code index} in {@code model}'s address book.
+     * @return the unfavorited person
      */
-    private ReadOnlyPerson favoritePerson(Model model, Index index) {
+    private ReadOnlyPerson unFavoritePerson(Model model, Index index) {
         ReadOnlyPerson targetPerson = model.getFilteredPersonList().get(index.getZeroBased());
         try {
-            model.toggleFavoritePerson(targetPerson, FavoriteCommand.COMMAND_WORD);
+            model.toggleFavoritePerson(targetPerson, UnFavoriteCommand.COMMAND_WORD);
         } catch (DuplicatePersonException dpe) {
             throw new AssertionError(EditCommand.MESSAGE_DUPLICATE_PERSON);
         } catch (PersonNotFoundException pnfe) {


### PR DESCRIPTION
**Fixes two issues**:
- Favorite and Unfavorite command on multiple persons operates on wrong persons due to new sorting implementation _(Fixes #110, Fixes #136)_
- Update on a person causes profile photo thumbnail color to change _(Fixes #109)_

**New updates**:
- Favorite and Unfavorite feature includes a new validation to prevent duplicate favoriting/unfavoriting e.g. `fav 1 1 1`
- Favorite feature disallows favoriting an already favorite person (also informs user about the invalid operation)
- Unfavorite feature disallows unfavoriting a person who is not a favorite in the first place (also informs user about the invalid operation)
- Add UnFavoriteCommandSystemTest